### PR TITLE
Feat/openapi and ws interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -30,7 +30,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64",
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "brotli",
  "bytes",
  "bytestring",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -315,6 +315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,7 +368,7 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
- "async-io 2.5.0",
+ "async-io 2.6.0",
  "async-lock 3.4.1",
  "blocking",
  "futures-lite 2.6.1",
@@ -388,20 +397,20 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock 3.4.1",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.6.1",
  "parking",
- "polling 3.10.0",
- "rustix 1.0.8",
+ "polling 3.11.0",
+ "rustix 1.1.2",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -432,7 +441,7 @@ checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
 dependencies = [
  "async-channel 1.9.0",
  "async-global-executor",
- "async-io 2.5.0",
+ "async-io 2.6.0",
  "async-lock 3.4.1",
  "crossbeam-utils",
  "futures-channel",
@@ -512,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -522,7 +531,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -545,9 +554,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
 ]
@@ -615,19 +624,20 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytestring"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
+checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
  "bytes",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -798,11 +808,22 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -904,12 +925,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -966,12 +987,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1152,14 +1180,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gloo-timers"
@@ -1204,12 +1232,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1412,12 +1446,14 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1446,7 +1482,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -1499,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1533,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libm"
@@ -1545,11 +1581,11 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "libc",
  "redox_syscall",
 ]
@@ -1566,6 +1602,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,9 +1618,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1631,15 +1676,25 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1734,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1759,7 +1814,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1909,16 +1964,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2049,14 +2104,14 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2066,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2108,6 +2163,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,15 +2218,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2153,12 +2242,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "schannel"
-version = "0.1.27"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "windows-sys 0.59.0",
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2173,7 +2271,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2182,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2293,6 +2391,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,7 +2491,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown",
+ "hashbrown 0.15.5",
  "hashlink",
  "indexmap",
  "log",
@@ -2450,7 +2554,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "byteorder",
  "bytes",
  "crc",
@@ -2492,7 +2596,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "byteorder",
  "crc",
  "dotenvy",
@@ -2565,6 +2669,9 @@ dependencies = [
  "serde_json",
  "sqlx",
  "unicode-normalization",
+ "utoipa",
+ "utoipa-rapidoc",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -2614,15 +2721,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2647,9 +2754,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -2662,15 +2769,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2772,6 +2879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,9 +2892,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-normalization"
@@ -2829,6 +2942,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "utoipa-rapidoc"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5e784e313457e79d65c378bdfc2f74275f0db91a72252be7d34360ec2afbe1"
+dependencies = [
+ "actix-web",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "actix-web",
+ "base64",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "value-bag"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +3020,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2860,9 +3037,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2875,21 +3061,22 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -2901,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2914,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2924,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2937,18 +3124,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2981,6 +3168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,9 +3184,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -3025,7 +3221,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3061,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
  "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
@@ -3216,9 +3421,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -3252,18 +3457,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3331,6 +3536,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
 name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3350,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-ws"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a1fb4f9f2794b0aadaf2ba5f14a6f034c7e86957b458c506a8cb75953f2d99"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytestring",
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1137,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1167,7 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2661,13 +2687,16 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "actix-web-httpauth",
+ "actix-ws",
  "awc",
  "clap",
  "env_logger",
+ "futures-util",
  "log",
  "serde",
  "serde_json",
  "sqlx",
+ "tokio",
  "unicode-normalization",
  "utoipa",
  "utoipa-rapidoc",
@@ -2824,7 +2853,19 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "socket2 0.6.0",
+ "tokio-macros",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 actix-web = "4.11"
 actix-web-httpauth = "0.8.2"
+actix-ws = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 sqlx = { version = "0.8.6", features = ["runtime-async-std-native-tls", "sqlite", "migrate"] }
 log = "0.4"
@@ -15,6 +16,9 @@ unicode-normalization = "0.1"
 utoipa = { version = "5", features = ["actix_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 utoipa-rapidoc = { version = "5", features = ["actix-web"] }
+tokio = { version = "1", features = ["sync", "macros"] }
+futures-util = "0.3"
+serde_json = "1"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ log = "0.4"
 env_logger = "0.11.8"
 clap = { version = "4.5", features = ["derive"] }
 unicode-normalization = "0.1"
+utoipa = { version = "5", features = ["actix_extras"] }
+utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
+utoipa-rapidoc = { version = "5", features = ["actix-web"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # stalk-api
 
 The small core of the program, to provide API to put and get stalk data from.
+
+OpenAPI documentation
+- Swagger UI: http://127.0.0.1:8080/api/swagger-ui
+- RapiDoc UI: http://127.0.0.1:8080/api/rapidoc
+- OpenAPI JSON: http://127.0.0.1:8080/api/openapi.json
+
+The API documentation is generated from code using utoipa and stays in sync with the handlers and models.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,9 @@ pub mod db;
 pub mod models;
 pub mod openapi;
 pub mod routes;
+pub mod utils;
 
-use actix_web::{web, App};
+use actix_web::web;
 use actix_web_httpauth::middleware::HttpAuthentication;
 use sqlx::{Pool, Sqlite};
 use utoipa::OpenApi;
@@ -14,6 +15,7 @@ use utoipa_swagger_ui::SwaggerUi;
 pub struct AppState {
     pub db: Pool<Sqlite>,
     pub auth_token: String,
+    pub notifier: tokio::sync::broadcast::Sender<crate::models::UserCoords>,
 }
 
 // Reuse the same bearer validator from main in both prod and tests
@@ -28,33 +30,46 @@ pub async fn validator(
             Err((actix_web::error::ErrorUnauthorized("invalid token"), req))
         }
     } else {
-        Err((actix_web::error::ErrorUnauthorized("authentication not configured"), req))
+        Err((
+            actix_web::error::ErrorUnauthorized("authentication not configured"),
+            req,
+        ))
     }
 }
 
 // Configure the Actix Web services exactly like main.rs so tests exercise the real paths
 pub fn configure_api(cfg: &mut web::ServiceConfig) {
     let auth = HttpAuthentication::bearer(validator);
-    cfg.service(actix_web::web::resource("/health").route(actix_web::web::get().to(crate::routes::health)))
-        .service(
-            web::scope("/api")
-                .service(
-                    web::resource("/coords")
-                        .route(web::post().to(crate::routes::update_location).wrap(auth.clone()))
-                        .route(web::get().to(crate::routes::get_locations)),
-                )
-                .service(
-                    web::resource("/coords/{name}")
-                        .route(web::get().to(crate::routes::get_user))
-                        .route(web::delete().to(crate::routes::delete_user).wrap(auth)),
-                )
-                .service(web::resource("/openapi.json").route(web::get().to(|| async {
+    cfg.service(
+        actix_web::web::resource("/health").route(actix_web::web::get().to(crate::routes::health)),
+    )
+    .service(crate::routes::ws_coords)
+    .service(crate::routes::ws_coords_user)
+    .service(
+        web::scope("/api")
+            .service(
+                web::resource("/coords")
+                    .route(
+                        web::post()
+                            .to(crate::routes::update_location)
+                            .wrap(auth.clone()),
+                    )
+                    .route(web::get().to(crate::routes::get_locations)),
+            )
+            .service(
+                web::resource("/coords/{name}")
+                    .route(web::get().to(crate::routes::get_user))
+                    .route(web::delete().to(crate::routes::delete_user).wrap(auth)),
+            )
+            .service(
+                web::resource("/openapi.json").route(web::get().to(|| async {
                     actix_web::HttpResponse::Ok().json(crate::openapi::ApiDoc::openapi())
-                })))
-                .service(
-                    SwaggerUi::new("/swagger-ui/{_:.*}")
-                        .url("/api/openapi.json", crate::openapi::ApiDoc::openapi()),
-                )
-                .service(RapiDoc::new("/api/openapi.json").path("/rapidoc")),
-        );
+                })),
+            )
+            .service(
+                SwaggerUi::new("/swagger-ui/{_:.*}")
+                    .url("/api/openapi.json", crate::openapi::ApiDoc::openapi()),
+            )
+            .service(RapiDoc::new("/api/openapi.json").path("/rapidoc")),
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,60 @@
 pub mod db;
 pub mod models;
+pub mod openapi;
 pub mod routes;
 
+use actix_web::{web, App};
+use actix_web_httpauth::middleware::HttpAuthentication;
 use sqlx::{Pool, Sqlite};
+use utoipa::OpenApi;
+use utoipa_rapidoc::RapiDoc;
+use utoipa_swagger_ui::SwaggerUi;
 
 // Database connection pool and configuration shared across handlers
 pub struct AppState {
     pub db: Pool<Sqlite>,
     pub auth_token: String,
+}
+
+// Reuse the same bearer validator from main in both prod and tests
+pub async fn validator(
+    req: actix_web::dev::ServiceRequest,
+    credentials: actix_web_httpauth::extractors::bearer::BearerAuth,
+) -> Result<actix_web::dev::ServiceRequest, (actix_web::Error, actix_web::dev::ServiceRequest)> {
+    if let Some(state) = req.app_data::<web::Data<AppState>>() {
+        if credentials.token() == state.auth_token {
+            Ok(req)
+        } else {
+            Err((actix_web::error::ErrorUnauthorized("invalid token"), req))
+        }
+    } else {
+        Err((actix_web::error::ErrorUnauthorized("authentication not configured"), req))
+    }
+}
+
+// Configure the Actix Web services exactly like main.rs so tests exercise the real paths
+pub fn configure_api(cfg: &mut web::ServiceConfig) {
+    let auth = HttpAuthentication::bearer(validator);
+    cfg.service(actix_web::web::resource("/health").route(actix_web::web::get().to(crate::routes::health)))
+        .service(
+            web::scope("/api")
+                .service(
+                    web::resource("/coords")
+                        .route(web::post().to(crate::routes::update_location).wrap(auth.clone()))
+                        .route(web::get().to(crate::routes::get_locations)),
+                )
+                .service(
+                    web::resource("/coords/{name}")
+                        .route(web::get().to(crate::routes::get_user))
+                        .route(web::delete().to(crate::routes::delete_user).wrap(auth)),
+                )
+                .service(web::resource("/openapi.json").route(web::get().to(|| async {
+                    actix_web::HttpResponse::Ok().json(crate::openapi::ApiDoc::openapi())
+                })))
+                .service(
+                    SwaggerUi::new("/swagger-ui/{_:.*}")
+                        .url("/api/openapi.json", crate::openapi::ApiDoc::openapi()),
+                )
+                .service(RapiDoc::new("/api/openapi.json").path("/rapidoc")),
+        );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use clap::Parser;
 use log::info;
 use sqlx::sqlite::SqlitePoolOptions;
 use stalk_api::AppState;
-use stalk_api::db::{check_and_create_db_file, migrate};
 use stalk_api::configure_api;
+use stalk_api::db::{check_and_create_db_file, migrate};
 use std::env;
 
 #[derive(Parser, Debug)]
@@ -70,11 +70,17 @@ async fn main() -> std::io::Result<()> {
     };
     // Start HTTP server and set up graceful shutdown
     let pool_clone = pool.clone();
+    // Create a broadcast channel for websocket notifications
+    let (coords_update_sender, _unused_coords_update_receiver) =
+        tokio::sync::broadcast::channel::<stalk_api::models::UserCoords>(1024);
+
     let server = HttpServer::new(move || {
+        let coords_update_sender = coords_update_sender.clone();
         App::new()
             .app_data(web::Data::new(AppState {
                 db: pool_clone.clone(),
                 auth_token: token.clone(),
+                notifier: coords_update_sender,
             }))
             .configure(configure_api)
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,10 @@
-use actix_web::dev::ServiceRequest;
-use actix_web::error::ErrorUnauthorized;
-use actix_web::{App, Error, HttpServer, web};
-use actix_web_httpauth::extractors::bearer::BearerAuth;
-use actix_web_httpauth::middleware::HttpAuthentication;
+use actix_web::{App, HttpServer, web};
 use clap::Parser;
 use log::info;
 use sqlx::sqlite::SqlitePoolOptions;
 use stalk_api::AppState;
 use stalk_api::db::{check_and_create_db_file, migrate};
-use stalk_api::routes::{delete_user, get_locations, get_user, health, update_location};
+use stalk_api::configure_api;
 use std::env;
 
 #[derive(Parser, Debug)]
@@ -29,22 +25,6 @@ struct Args {
     /// Database file to use
     #[arg(short, long, default_value = "coords.sqlite")]
     db_file: String,
-}
-
-async fn validator(
-    req: ServiceRequest,
-    credentials: BearerAuth,
-) -> Result<ServiceRequest, (Error, ServiceRequest)> {
-    // Read the token from application state loaded at startup
-    if let Some(state) = req.app_data::<web::Data<AppState>>() {
-        if credentials.token() == state.auth_token {
-            Ok(req)
-        } else {
-            Err((ErrorUnauthorized("invalid token"), req))
-        }
-    } else {
-        Err((ErrorUnauthorized("authentication not configured"), req))
-    }
 }
 
 #[actix_web::main]
@@ -91,27 +71,12 @@ async fn main() -> std::io::Result<()> {
     // Start HTTP server and set up graceful shutdown
     let pool_clone = pool.clone();
     let server = HttpServer::new(move || {
-        let auth = HttpAuthentication::bearer(validator);
         App::new()
             .app_data(web::Data::new(AppState {
                 db: pool_clone.clone(),
                 auth_token: token.clone(),
             }))
-            // Public health endpoint (no auth)
-            .service(web::resource("/health").route(web::get().to(health)))
-            .service(
-                web::scope("/api")
-                    .service(
-                        web::resource("/coords")
-                            .route(web::post().to(update_location).wrap(auth.clone()))
-                            .route(web::get().to(get_locations)),
-                    )
-                    .service(
-                        web::resource("/coords/{name}")
-                            .route(web::get().to(get_user))
-                            .route(web::delete().to(delete_user).wrap(auth)),
-                    ),
-            )
+            .configure(configure_api)
     })
     .shutdown_timeout(5)
     .disable_signals()

--- a/src/models/coords.rs
+++ b/src/models/coords.rs
@@ -1,21 +1,29 @@
 use serde::{Deserialize, Serialize};
 use unicode_normalization::UnicodeNormalization;
+use utoipa::ToSchema;
 
 // Define our item structure for storage/response
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct UserCoords {
+    #[schema(example = "hannes")]
     pub name: String,
+    #[schema(example = 59.334)]
     pub latitude: f64,
+    #[schema(example = 18.063)]
     pub longitude: f64,
+    #[schema(format = DateTime, example = "2025-09-27T14:20:00.000Z")]
     pub timestamp: Option<String>,
 }
 
 // Input DTO without timestamp; reject unknown fields (e.g., client-sent timestamp)
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct NewUserCoords {
+    #[schema(example = "marin")]
     pub name: String,
+    #[schema(example = 59.3325)]
     pub latitude: f64,
+    #[schema(example = 18.0649)]
     pub longitude: f64,
 }
 

--- a/src/models/coords.rs
+++ b/src/models/coords.rs
@@ -3,7 +3,7 @@ use unicode_normalization::UnicodeNormalization;
 use utoipa::ToSchema;
 
 // Define our item structure for storage/response
-#[derive(Serialize, Deserialize, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct UserCoords {
     #[schema(example = "hannes")]
     pub name: String,
@@ -16,7 +16,29 @@ pub struct UserCoords {
 }
 
 // Input DTO without timestamp; reject unknown fields (e.g., client-sent timestamp)
-#[derive(Deserialize, Debug, ToSchema)]
+///
+/// The struct denies unknown fields so clients cannot sneak in a `timestamp` or
+/// any other unexpected property.
+///
+/// Examples
+///
+/// Successful deserialization from JSON:
+/// ```
+/// use stalk_api::models::NewUserCoords;
+/// let json = r#"{"name":"marin","latitude":59.3325,"longitude":18.0649}"#;
+/// let dto: NewUserCoords = serde_json::from_str(json).unwrap();
+/// assert_eq!(dto.name, "marin");
+/// ```
+///
+/// Unknown fields are rejected:
+/// ```
+/// use stalk_api::models::NewUserCoords;
+/// let json_with_unknown = r#"{"name":"m","latitude":1.0,"longitude":2.0,"timestamp":"2020-01-01T00:00:00Z"}"#;
+/// let err = serde_json::from_str::<NewUserCoords>(json_with_unknown).unwrap_err();
+/// let msg = err.to_string();
+/// assert!(msg.contains("unknown field") && msg.contains("timestamp"));
+/// ```
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct NewUserCoords {
     #[schema(example = "marin")]

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -23,6 +23,8 @@ impl Modify for SecurityAddon {
         crate::routes::get_user,
         crate::routes::update_location,
         crate::routes::delete_user,
+        crate::routes::ws_coords,
+        crate::routes::ws_coords_user,
     ),
     components(
         schemas(UserCoords, NewUserCoords, HealthResponse)
@@ -33,4 +35,16 @@ impl Modify for SecurityAddon {
         (name = "coords", description = "Coordinates API")
     )
 )]
+/// OpenAPI document for the service.
+///
+/// # Examples
+///
+/// The generated OpenAPI document contains the REST and WebSocket paths:
+/// ```
+/// use utoipa::OpenApi;
+/// use stalk_api::openapi::ApiDoc;
+/// let json = serde_json::to_string(&ApiDoc::openapi()).unwrap();
+/// assert!(json.contains("/api/coords"));
+/// assert!(json.contains("/ws/coords"));
+/// ```
 pub struct ApiDoc;

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,0 +1,36 @@
+use crate::models::{NewUserCoords, UserCoords};
+use crate::routes::HealthResponse;
+use utoipa::openapi::security::{Http, HttpAuthScheme, SecurityScheme};
+use utoipa::{Modify, OpenApi};
+
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi.components.get_or_insert_with(Default::default);
+        components.add_security_scheme(
+            "ApiToken",
+            SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)),
+        );
+    }
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        crate::routes::health,
+        crate::routes::get_locations,
+        crate::routes::get_user,
+        crate::routes::update_location,
+        crate::routes::delete_user,
+    ),
+    components(
+        schemas(UserCoords, NewUserCoords, HealthResponse)
+    ),
+    modifiers(&SecurityAddon),
+    tags(
+        (name = "health", description = "Health check"),
+        (name = "coords", description = "Coordinates API")
+    )
+)]
+pub struct ApiDoc;

--- a/src/routes/coords.rs
+++ b/src/routes/coords.rs
@@ -48,6 +48,8 @@ pub async fn update_location(state: Data<AppState>, body: Json<NewUserCoords>) -
 
     match result {
         Ok(coords) => {
+            // Publish update to websocket subscribers; ignore if there are no receivers
+            let _ = state.notifier.send(coords.clone());
             if existed {
                 HttpResponse::Ok().json(coords)
             } else {

--- a/src/routes/coords.rs
+++ b/src/routes/coords.rs
@@ -10,6 +10,22 @@ use actix_web::web::{Data, Json, Path};
 use actix_web::{HttpResponse, Responder};
 use log::{debug, error};
 
+/// Create or update a user's coordinates
+#[utoipa::path(
+    post,
+    path = "/api/coords",
+    request_body = NewUserCoords,
+    responses(
+        (status = 200, description = "Updated existing user coordinates", body = UserCoords),
+        (status = 201, description = "Created new user coordinates", body = UserCoords, headers(
+            ("Location" = String, description = "Resource location")
+        )),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(("ApiToken" = [])),
+    tag = "coords"
+)]
 pub async fn update_location(state: Data<AppState>, body: Json<NewUserCoords>) -> impl Responder {
     debug!("Updating user coords: {body:?}");
     let validated: Result<UserCoords, String> = validate_and_normalize(body.into_inner());
@@ -49,6 +65,15 @@ pub async fn update_location(state: Data<AppState>, body: Json<NewUserCoords>) -
 }
 
 // Handler for getting all items
+#[utoipa::path(
+    get,
+    path = "/api/coords",
+    responses(
+        (status = 200, description = "List of current user coordinates", body = [UserCoords]),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "coords"
+)]
 pub async fn get_locations(state: Data<AppState>) -> impl Responder {
     debug!("Get all user coords");
     let result = get_all_coords_time_limited(&state.db).await;
@@ -60,6 +85,19 @@ pub async fn get_locations(state: Data<AppState>) -> impl Responder {
 }
 
 // Handler for getting a single item by ID
+#[utoipa::path(
+    get,
+    path = "/api/coords/{name}",
+    params(
+        ("name" = String, Path, description = "User name")
+    ),
+    responses(
+        (status = 200, description = "User coordinates", body = UserCoords),
+        (status = 404, description = "User not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "coords"
+)]
 pub async fn get_user(state: Data<AppState>, name: Path<String>) -> impl Responder {
     let username_raw = name.as_str();
     let username = normalize_name(username_raw);
@@ -73,6 +111,20 @@ pub async fn get_user(state: Data<AppState>, name: Path<String>) -> impl Respond
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/api/coords/{name}",
+    params(
+        ("name" = String, Path, description = "User name")
+    ),
+    responses(
+        (status = 204, description = "User deleted"),
+        (status = 404, description = "User not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(("ApiToken" = [])),
+    tag = "coords"
+)]
 pub async fn delete_user(state: Data<AppState>, name: Path<String>) -> impl Responder {
     let username_raw = name.as_str();
     let username = normalize_name(username_raw);

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,7 @@
 mod coords;
 pub use coords::*;
+mod ws;
+pub use ws::*;
 
 use actix_web::{HttpResponse, Responder};
 use serde::Serialize;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,13 +3,23 @@ pub use coords::*;
 
 use actix_web::{HttpResponse, Responder};
 use serde::Serialize;
+use utoipa::ToSchema;
 
-#[derive(Serialize)]
-struct HealthResponse {
-    status: &'static str,
+#[derive(Serialize, ToSchema)]
+pub struct HealthResponse {
+    #[schema(example = "ok")]
+    pub status: &'static str,
 }
 
-// Public health check endpoint (no auth)
+/// Health check endpoint
+#[utoipa::path(
+    get,
+    path = "/health",
+    responses(
+        (status = 200, description = "Service is healthy", body = HealthResponse)
+    ),
+    tag = "health"
+)]
 pub async fn health() -> impl Responder {
     HttpResponse::Ok().json(HealthResponse { status: "ok" })
 }

--- a/src/routes/ws.rs
+++ b/src/routes/ws.rs
@@ -1,0 +1,226 @@
+use crate::models::normalize_name;
+use crate::{
+    AppState,
+    db::{get_all_coords_time_limited, get_specific_user_coords_time_limited},
+};
+use actix_web::{Error as ActixError, HttpRequest, HttpResponse, get, web};
+use actix_ws::Message;
+use futures_util::StreamExt;
+use log::{debug, error, info, warn};
+
+#[derive(serde::Deserialize)]
+struct WsAllUsersQuery {
+    /// If true, server sends an initial load as individual UserCoords frames before live updates.
+    /// Accepts only `true`/`false` or `1`/`0` (as strings are typical in query params). Other values are rejected.
+    #[serde(default, deserialize_with = "de_bool_or_one")]
+    initial: bool,
+}
+
+fn de_bool_or_one<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{Error as DeError, Unexpected};
+    struct Visitor;
+    impl<'de> serde::de::Visitor<'de> for Visitor {
+        type Value = bool;
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a string 'true'/'false' or '1'/'0'")
+        }
+        fn visit_str<E: DeError>(self, v: &str) -> Result<bool, E> {
+            let s = v.trim().to_ascii_lowercase();
+            match s.as_str() {
+                "true" | "1" => Ok(true),
+                "false" | "0" => Ok(false),
+                _ => Err(E::invalid_value(
+                    Unexpected::Str(v),
+                    &"'true'/'false' or '1'/'0'",
+                )),
+            }
+        }
+    }
+    // Actix Query params are strings; deserialize from string only.
+    deserializer.deserialize_str(Visitor)
+}
+
+/// WebSocket endpoint streaming all user coordinate updates.
+#[utoipa::path(
+    get,
+    path = "/ws/coords",
+    params(
+        ("initial" = bool, Query, description = "When true (accepts only true/false or 1/0), send an initial load of all current users as individual update frames before streaming live updates")
+    ),
+    responses(
+        (status = 101, description = "Switching Protocols: WebSocket upgrade to a stream of JSON UserCoords messages"),
+        (status = 400, description = "Bad request")
+    ),
+    tag = "coords"
+)]
+#[get("/ws/coords")]
+pub async fn ws_coords(
+    req: HttpRequest,
+    stream: web::Payload,
+    state: web::Data<AppState>,
+    query: web::Query<WsAllUsersQuery>,
+) -> Result<HttpResponse, ActixError> {
+    let (resp, mut ws_session, mut client_incoming) = match actix_ws::handle(&req, stream) {
+        Ok(parts) => parts,
+        Err(err) => {
+            error!("WS handshake failed: {err:?}");
+            return Err(err);
+        }
+    };
+
+    let initial = query.initial;
+    info!("WS connected: all-users initial={initial}");
+
+    // If requested, send an initial load as individual update frames
+    if initial {
+        match get_all_coords_time_limited(&state.db).await {
+            Ok(list) => {
+                for coords in list {
+                    match serde_json::to_string(&coords) {
+                        Ok(s) => {
+                            if let Err(e) = ws_session.text(s).await {
+                                debug!("WS send error during initial snapshot, closing: {e:?}");
+                                let _ = ws_session.close(None).await;
+                                return Ok(resp);
+                            }
+                        }
+                        Err(e) => {
+                            error!("Serialize error during initial snapshot: {e:?}");
+                            break;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("Initial snapshot fetch failed: {e:?}");
+            }
+        }
+    }
+
+    let mut updates_receiver = state.notifier.subscribe();
+
+    actix_web::rt::spawn(async move {
+        loop {
+            tokio::select! {
+                // Receive broadcast of updates
+                update_result = updates_receiver.recv() => {
+                    match update_result {
+                        Ok(coords) => {
+                            let json = match serde_json::to_string(&coords) {
+                                Ok(s) => s,
+                                Err(e) => { error!("Serialize error: {e:?}"); break; }
+                            };
+                            if let Err(e) = ws_session.text(json).await {
+                                debug!("WS send error, closing: {e:?}");
+                                break;
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("WS consumer lagged by {n} messages; dropping to latest");
+                            continue;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            debug!("WS broadcaster closed");
+                            break;
+                        }
+                    }
+                }
+                // Handle client messages (we don't expect any; just react to close)
+                incoming = client_incoming.next() => {
+                    match incoming {
+                        Some(Ok(Message::Close(_))) => { debug!("WS client closed"); break; }
+                        Some(Ok(Message::Ping(bytes))) => { let _ = ws_session.pong(&bytes).await; }
+                        Some(Ok(Message::Text(_)| Message::Binary(_)| Message::Continuation(_))) => { /* ignore */ }
+                        Some(Ok(Message::Pong(_))) => { /* ignore */ }
+                        Some(Ok(Message::Nop)) => { /* ignore */ }
+                        None => { break; }
+                        Some(Err(e)) => { debug!("WS protocol error: {e:?}"); break; }
+                    }
+                }
+            }
+        }
+        let _ = ws_session.close(None).await;
+        info!("WS disconnected: all-users");
+    });
+
+    Ok(resp)
+}
+
+/// WebSocket endpoint streaming updates for a single user. Optionally sends snapshot on connect.
+#[utoipa::path(
+    get,
+    path = "/ws/coords/{name}",
+    params(
+        ("name" = String, Path, description = "User name (case-insensitive)")
+    ),
+    responses(
+        (status = 101, description = "Switching Protocols: WebSocket upgrade to a stream of JSON UserCoords messages filtered by user"),
+        (status = 400, description = "Bad request")
+    ),
+    tag = "coords"
+)]
+#[get("/ws/coords/{name}")]
+pub async fn ws_coords_user(
+    req: HttpRequest,
+    stream: web::Payload,
+    state: web::Data<AppState>,
+    name: web::Path<String>,
+) -> Result<HttpResponse, ActixError> {
+    let (resp, mut ws_session, mut client_incoming) = match actix_ws::handle(&req, stream) {
+        Ok(parts) => parts,
+        Err(err) => {
+            error!("WS handshake failed: {err:?}");
+            return Err(err);
+        }
+    };
+
+    let name_raw = name.into_inner();
+    let username = normalize_name(&name_raw);
+    info!("WS connected: user={username}");
+
+    // Optionally send a snapshot if available
+    if let Ok(Some(snapshot)) = get_specific_user_coords_time_limited(&state.db, &username).await
+        && let Ok(json) = serde_json::to_string(&snapshot)
+    {
+        let _ = ws_session.text(json).await;
+    }
+
+    let mut updates_receiver = state.notifier.subscribe();
+
+    actix_web::rt::spawn(async move {
+        loop {
+            tokio::select! {
+                update_result = updates_receiver.recv() => {
+                    match update_result {
+                        Ok(coords) => {
+                            if coords.name.eq_ignore_ascii_case(&username) { // names are stored normalized in DB, compare case-insensitively
+                                let json = match serde_json::to_string(&coords) { Ok(s) => s, Err(e) => { error!("Serialize error: {e:?}"); break; } };
+                                if let Err(e) = ws_session.text(json).await { debug!("WS send error, closing: {e:?}"); break; }
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => { warn!("WS consumer lagged by {n} messages; dropping to latest"); continue; }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => { debug!("WS broadcaster closed"); break; }
+                    }
+                }
+                incoming = client_incoming.next() => {
+                    match incoming {
+                        Some(Ok(Message::Close(_))) => { debug!("WS client closed"); break; }
+                        Some(Ok(Message::Ping(bytes))) => { let _ = ws_session.pong(&bytes).await; }
+                        Some(Ok(Message::Text(_)| Message::Binary(_)| Message::Continuation(_))) => { /* ignore */ }
+                        Some(Ok(Message::Pong(_))) => { /* ignore */ }
+                        Some(Ok(Message::Nop)) => { /* ignore */ }
+                        None => { break; }
+                        Some(Err(e)) => { debug!("WS protocol error: {e:?}"); break; }
+                    }
+                }
+            }
+        }
+        let _ = ws_session.close(None).await;
+        info!("WS disconnected: user={username}");
+    });
+
+    Ok(resp)
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,43 @@
+/// Utilities for testing and client helpers.
+///
+/// Currently exposes `ws_url`, a tiny helper that turns a base http(s) URL into
+/// a ws(s) URL and appends a WebSocket path. This is handy in tests and
+/// examples when spinning up an ephemeral HTTP server and then connecting via
+/// WebSocket.
+///
+/// The function is intentionally simple and assumes `path` starts with `/`.
+///
+/// # Examples
+///
+/// Convert http -> ws and append path:
+///
+/// ```
+/// use stalk_api::utils::ws_url;
+/// assert_eq!(ws_url("http://my-http-site.com", "/ws"), "ws://my-http-site.com/ws");
+/// ```
+///
+/// Handle trailing slash on the base URL without producing a double slash:
+///
+/// ```
+/// use stalk_api::utils::ws_url;
+/// assert_eq!(ws_url("http://my-http-site.com/", "/ws"), "ws://my-http-site.com/ws");
+/// ```
+///
+/// HTTPS becomes WSS:
+///
+/// ```
+/// use stalk_api::utils::ws_url;
+/// assert_eq!(ws_url("https://example.org", "/ws/coords"), "wss://example.org/ws/coords");
+/// ```
+pub fn ws_url(http_url: &str, path: &str) -> String {
+    let base = http_url.trim_end_matches('/');
+    // Only rewrite the scheme prefix, leave the rest untouched.
+    let rewritten = if base.starts_with("https://") {
+        base.replacen("https", "wss", 1)
+    } else if base.starts_with("http://") {
+        base.replacen("http", "ws", 1)
+    } else {
+        base.to_string()
+    };
+    format!("{}{}", rewritten, path)
+}

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,31 +1,9 @@
 use actix_web::http::{Method, StatusCode, header};
 use actix_web::{App, HttpServer, test, web};
-use actix_web_httpauth::extractors::bearer::BearerAuth;
-use actix_web_httpauth::middleware::HttpAuthentication;
 use awc::Client;
 use sqlx::sqlite::SqlitePoolOptions;
-use stalk_api::AppState;
-use stalk_api::routes::{delete_user, get_locations, get_user, health, update_location};
+use stalk_api::{AppState, configure_api};
 use std::net::TcpListener;
-
-// Local auth validator mirroring main.rs behavior (checks AppState.auth_token)
-async fn validator(
-    req: actix_web::dev::ServiceRequest,
-    credentials: BearerAuth,
-) -> Result<actix_web::dev::ServiceRequest, (actix_web::Error, actix_web::dev::ServiceRequest)> {
-    if let Some(state) = req.app_data::<web::Data<AppState>>() {
-        if credentials.token() == state.auth_token {
-            Ok(req)
-        } else {
-            Err((actix_web::error::ErrorUnauthorized("invalid token"), req))
-        }
-    } else {
-        Err((
-            actix_web::error::ErrorUnauthorized("authentication not configured"),
-            req,
-        ))
-    }
-}
 
 async fn build_pool_and_token() -> (sqlx::Pool<sqlx::Sqlite>, String) {
     let pool = SqlitePoolOptions::new()
@@ -43,27 +21,22 @@ async fn build_pool_and_token() -> (sqlx::Pool<sqlx::Sqlite>, String) {
     (pool, "test-token".to_string())
 }
 
+fn make_state(db: sqlx::Pool<sqlx::Sqlite>, token: String) -> web::Data<AppState> {
+    let (coords_update_sender, _unused_receiver) = tokio::sync::broadcast::channel(16);
+    web::Data::new(AppState {
+        db,
+        auth_token: token,
+        notifier: coords_update_sender,
+    })
+}
+
 #[actix_web::test]
 async fn health_returns_ok_json() {
     let (pool, token) = build_pool_and_token().await;
-    let auth = HttpAuthentication::bearer(validator);
-
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(AppState {
-                db: pool.clone(),
-                auth_token: token,
-            }))
-            .service(web::resource("/health").route(web::get().to(health)))
-            .service(
-                web::scope("/api")
-                    .service(
-                        web::resource("/coords")
-                            .route(web::post().to(update_location).wrap(auth.clone()))
-                            .route(web::get().to(get_locations)),
-                    )
-                    .service(web::resource("/coords/{name}").route(web::get().to(get_user))),
-            ),
+            .app_data(make_state(pool.clone(), token.clone()))
+            .configure(configure_api),
     )
     .await;
 
@@ -77,24 +50,11 @@ async fn health_returns_ok_json() {
 #[actix_web::test]
 async fn post_coords_requires_auth() {
     let (pool, token) = build_pool_and_token().await;
-    let auth = HttpAuthentication::bearer(validator);
 
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(AppState {
-                db: pool.clone(),
-                auth_token: token,
-            }))
-            .service(web::resource("/health").route(web::get().to(health)))
-            .service(
-                web::scope("/api")
-                    .service(
-                        web::resource("/coords")
-                            .route(web::post().to(update_location).wrap(auth.clone()))
-                            .route(web::get().to(get_locations)),
-                    )
-                    .service(web::resource("/coords/{name}").route(web::get().to(get_user))),
-            ),
+            .app_data(make_state(pool.clone(), token.clone()))
+            .configure(configure_api),
     )
     .await;
 
@@ -144,24 +104,11 @@ async fn post_coords_requires_auth() {
 #[actix_web::test]
 async fn get_user_happy_path_and_not_found_and_case_insensitive() {
     let (pool, token) = build_pool_and_token().await;
-    let auth = HttpAuthentication::bearer(validator);
 
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(AppState {
-                db: pool.clone(),
-                auth_token: token,
-            }))
-            .service(web::resource("/health").route(web::get().to(health)))
-            .service(
-                web::scope("/api")
-                    .service(
-                        web::resource("/coords")
-                            .route(web::post().to(update_location).wrap(auth.clone()))
-                            .route(web::get().to(get_locations)),
-                    )
-                    .service(web::resource("/coords/{name}").route(web::get().to(get_user))),
-            ),
+            .app_data(make_state(pool.clone(), token.clone()))
+            .configure(configure_api),
     )
     .await;
 
@@ -198,24 +145,11 @@ async fn get_user_happy_path_and_not_found_and_case_insensitive() {
 #[actix_web::test]
 async fn options_does_not_500() {
     let (pool, token) = build_pool_and_token().await;
-    let auth = HttpAuthentication::bearer(validator);
 
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(AppState {
-                db: pool.clone(),
-                auth_token: token,
-            }))
-            .service(web::resource("/health").route(web::get().to(health)))
-            .service(
-                web::scope("/api")
-                    .service(
-                        web::resource("/coords")
-                            .route(web::post().to(update_location).wrap(auth.clone()))
-                            .route(web::get().to(get_locations)),
-                    )
-                    .service(web::resource("/coords/{name}").route(web::get().to(get_user))),
-            ),
+            .app_data(make_state(pool.clone(), token.clone()))
+            .configure(configure_api),
     )
     .await;
 
@@ -236,23 +170,10 @@ async fn smoke_boot_server_and_health() {
     let addr = listener.local_addr().unwrap();
 
     // Build server
-    let auth = HttpAuthentication::bearer(validator);
     let server = HttpServer::new(move || {
         App::new()
-            .app_data(web::Data::new(AppState {
-                db: pool.clone(),
-                auth_token: token.clone(),
-            }))
-            .service(web::resource("/health").route(web::get().to(health)))
-            .service(
-                web::scope("/api")
-                    .service(
-                        web::resource("/coords")
-                            .route(web::post().to(update_location).wrap(auth.clone()))
-                            .route(web::get().to(get_locations)),
-                    )
-                    .service(web::resource("/coords/{name}").route(web::get().to(get_user))),
-            )
+            .app_data(make_state(pool.clone(), token.clone()))
+            .configure(configure_api)
     })
     .listen(listener)
     .expect("listen")
@@ -273,28 +194,11 @@ async fn smoke_boot_server_and_health() {
 #[actix_web::test]
 async fn delete_requires_auth() {
     let (pool, token) = build_pool_and_token().await;
-    let auth = HttpAuthentication::bearer(validator);
 
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(AppState {
-                db: pool.clone(),
-                auth_token: token,
-            }))
-            .service(web::resource("/health").route(web::get().to(health)))
-            .service(
-                web::scope("/api")
-                    .service(
-                        web::resource("/coords")
-                            .route(web::post().to(update_location).wrap(auth.clone()))
-                            .route(web::get().to(get_locations)),
-                    )
-                    .service(
-                        web::resource("/coords/{name}")
-                            .route(web::get().to(get_user))
-                            .route(web::delete().to(delete_user).wrap(auth.clone())),
-                    ),
-            ),
+            .app_data(make_state(pool.clone(), token.clone()))
+            .configure(configure_api),
     )
     .await;
 
@@ -317,28 +221,11 @@ async fn delete_requires_auth() {
 #[actix_web::test]
 async fn delete_flow_create_then_delete_then_404() {
     let (pool, token) = build_pool_and_token().await;
-    let auth = HttpAuthentication::bearer(validator);
 
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(AppState {
-                db: pool.clone(),
-                auth_token: token,
-            }))
-            .service(web::resource("/health").route(web::get().to(health)))
-            .service(
-                web::scope("/api")
-                    .service(
-                        web::resource("/coords")
-                            .route(web::post().to(update_location).wrap(auth.clone()))
-                            .route(web::get().to(get_locations)),
-                    )
-                    .service(
-                        web::resource("/coords/{name}")
-                            .route(web::get().to(get_user))
-                            .route(web::delete().to(delete_user).wrap(auth.clone())),
-                    ),
-            ),
+            .app_data(make_state(pool.clone(), token.clone()))
+            .configure(configure_api),
     )
     .await;
 

--- a/tests/openapi_spec.rs
+++ b/tests/openapi_spec.rs
@@ -1,6 +1,6 @@
-use actix_web::{test, App, web};
+use actix_web::{App, test, web};
 use sqlx::sqlite::SqlitePoolOptions;
-use stalk_api::{configure_api, AppState};
+use stalk_api::{AppState, configure_api};
 
 #[actix_web::test]
 async fn openapi_json_and_uis_are_served_under_api_scope() {
@@ -11,7 +11,12 @@ async fn openapi_json_and_uis_are_served_under_api_scope() {
         .await
         .expect("in-memory sqlite");
 
-    let state = AppState { db: pool, auth_token: "test-token".to_string() };
+    let (coords_update_sender, _unused_receiver) = tokio::sync::broadcast::channel(16);
+    let state = AppState {
+        db: pool,
+        auth_token: "test-token".to_string(),
+        notifier: coords_update_sender,
+    };
 
     // Build app using the same configuration as production
     let app = test::init_service(
@@ -24,7 +29,11 @@ async fn openapi_json_and_uis_are_served_under_api_scope() {
     // Assert OpenAPI JSON is served at /api/openapi.json
     let req = test::TestRequest::with_uri("/api/openapi.json").to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success(), "Expected 200, got {:?}", resp.status());
+    assert!(
+        resp.status().is_success(),
+        "Expected 200, got {:?}",
+        resp.status()
+    );
 
     let body = test::read_body(resp).await;
     let body_str = String::from_utf8(body.to_vec()).unwrap();
@@ -36,8 +45,8 @@ async fn openapi_json_and_uis_are_served_under_api_scope() {
 
     // Verify timestamp is documented as RFC 3339 date-time formatted string
     let json: serde_json::Value = serde_json::from_str(&body_str).expect("valid json");
-    let ts_format = json["components"]["schemas"]["UserCoords"]["properties"]["timestamp"]["format"]
-        .as_str();
+    let ts_format =
+        json["components"]["schemas"]["UserCoords"]["properties"]["timestamp"]["format"].as_str();
     assert_eq!(
         ts_format,
         Some("date-time"),
@@ -45,8 +54,8 @@ async fn openapi_json_and_uis_are_served_under_api_scope() {
     );
 
     // Verify HealthResponse has example for status
-    let health_status_example = json["components"]["schemas"]["HealthResponse"]["properties"]["status"]["example"]
-        .as_str();
+    let health_status_example =
+        json["components"]["schemas"]["HealthResponse"]["properties"]["status"]["example"].as_str();
     assert_eq!(
         health_status_example,
         Some("ok"),
@@ -56,10 +65,16 @@ async fn openapi_json_and_uis_are_served_under_api_scope() {
     // Assert RapiDoc UI is served under /api
     let rapidoc_req = test::TestRequest::with_uri("/api/rapidoc").to_request();
     let rapidoc_resp = test::call_service(&app, rapidoc_req).await;
-    assert!(rapidoc_resp.status().is_success(), "RapiDoc UI should return success");
+    assert!(
+        rapidoc_resp.status().is_success(),
+        "RapiDoc UI should return success"
+    );
 
     // Assert Swagger UI is served under /api
     let swagger_req = test::TestRequest::with_uri("/api/swagger-ui/").to_request();
     let swagger_resp = test::call_service(&app, swagger_req).await;
-    assert!(swagger_resp.status().is_success(), "Swagger UI should return success");
+    assert!(
+        swagger_resp.status().is_success(),
+        "Swagger UI should return success"
+    );
 }

--- a/tests/openapi_spec.rs
+++ b/tests/openapi_spec.rs
@@ -1,0 +1,65 @@
+use actix_web::{test, App, web};
+use sqlx::sqlite::SqlitePoolOptions;
+use stalk_api::{configure_api, AppState};
+
+#[actix_web::test]
+async fn openapi_json_and_uis_are_served_under_api_scope() {
+    // Prepare a minimal state; the doc/health endpoints do not hit the DB, but we provide a pool.
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite");
+
+    let state = AppState { db: pool, auth_token: "test-token".to_string() };
+
+    // Build app using the same configuration as production
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state))
+            .configure(configure_api),
+    )
+    .await;
+
+    // Assert OpenAPI JSON is served at /api/openapi.json
+    let req = test::TestRequest::with_uri("/api/openapi.json").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success(), "Expected 200, got {:?}", resp.status());
+
+    let body = test::read_body(resp).await;
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+    assert!(
+        body_str.contains("/api/coords"),
+        "OpenAPI JSON should contain /api/coords path",
+    );
+
+    // Verify timestamp is documented as RFC 3339 date-time formatted string
+    let json: serde_json::Value = serde_json::from_str(&body_str).expect("valid json");
+    let ts_format = json["components"]["schemas"]["UserCoords"]["properties"]["timestamp"]["format"]
+        .as_str();
+    assert_eq!(
+        ts_format,
+        Some("date-time"),
+        "timestamp should have format=date-time in OpenAPI schema"
+    );
+
+    // Verify HealthResponse has example for status
+    let health_status_example = json["components"]["schemas"]["HealthResponse"]["properties"]["status"]["example"]
+        .as_str();
+    assert_eq!(
+        health_status_example,
+        Some("ok"),
+        "HealthResponse.status should have example 'ok'"
+    );
+
+    // Assert RapiDoc UI is served under /api
+    let rapidoc_req = test::TestRequest::with_uri("/api/rapidoc").to_request();
+    let rapidoc_resp = test::call_service(&app, rapidoc_req).await;
+    assert!(rapidoc_resp.status().is_success(), "RapiDoc UI should return success");
+
+    // Assert Swagger UI is served under /api
+    let swagger_req = test::TestRequest::with_uri("/api/swagger-ui/").to_request();
+    let swagger_resp = test::call_service(&app, swagger_req).await;
+    assert!(swagger_resp.status().is_success(), "Swagger UI should return success");
+}

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -1,0 +1,270 @@
+use actix_web::{App, HttpServer, web};
+use futures_util::StreamExt;
+use serde_json::Value;
+use sqlx::sqlite::SqlitePoolOptions;
+use stalk_api::utils::ws_url;
+use stalk_api::{AppState, configure_api, models::NewUserCoords};
+use std::net::TcpListener;
+
+async fn setup_pool() -> sqlx::Pool<sqlx::Sqlite> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite");
+    // Run migrations
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("migrations");
+    pool
+}
+
+#[actix_web::test]
+async fn ws_all_users_stream_receives_updates() {
+    let pool = setup_pool().await;
+    let token = "test-token".to_string();
+    let (coords_update_sender, _unused_receiver) = tokio::sync::broadcast::channel(64);
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let server = HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(AppState {
+                db: pool.clone(),
+                auth_token: token.clone(),
+                notifier: coords_update_sender.clone(),
+            }))
+            .configure(configure_api)
+    })
+    .listen(listener)
+    .expect("listen")
+    .run();
+    let _handle = actix_web::rt::spawn(server);
+    let base_url = format!("http://{}", addr);
+
+    let client = awc::Client::new();
+    // Connect WebSocket
+    let url = ws_url(&base_url, "/ws/coords");
+    let (_resp, mut ws) = client.ws(url).connect().await.expect("ws connect");
+
+    // Trigger an update via REST
+    let body = NewUserCoords {
+        name: "Alice".into(),
+        latitude: 10.0,
+        longitude: 20.0,
+    };
+    let resp = client
+        .post(format!("{}/api/coords", base_url))
+        .insert_header(("Authorization", format!("Bearer {}", "test-token")))
+        .send_json(&body)
+        .await
+        .expect("post ok");
+    assert!(resp.status().is_success());
+
+    // Expect to receive a WS message
+    let frame = ws.next().await.expect("one message").expect("ok frame");
+    match frame {
+        awc::ws::Frame::Text(bytes) => {
+            let text = String::from_utf8(bytes.to_vec()).unwrap();
+            let json: Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(json["name"], "Alice");
+            assert_eq!(json["latitude"], 10.0);
+            assert_eq!(json["longitude"], 20.0);
+        }
+        other => panic!("unexpected frame: {:?}", other),
+    }
+}
+
+#[actix_web::test]
+async fn ws_per_user_isolation_and_case_insensitive() {
+    let pool = setup_pool().await;
+    let token = "test-token".to_string();
+    let (coords_update_sender, _unused_receiver) = tokio::sync::broadcast::channel(64);
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let server = HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(AppState {
+                db: pool.clone(),
+                auth_token: token.clone(),
+                notifier: coords_update_sender.clone(),
+            }))
+            .configure(configure_api)
+    })
+    .listen(listener)
+    .expect("listen")
+    .run();
+    let _handle = actix_web::rt::spawn(server);
+    let base_url = format!("http://{}", addr);
+
+    let client = awc::Client::new();
+    let url = ws_url(&base_url, "/ws/coords/ALICE");
+    let (_resp, mut ws) = client.ws(url).connect().await.expect("ws connect");
+
+    // Send updates for Alice and Bob, mixed case
+    for (name, lat) in [("Alice", 1.0), ("BOB", 2.0), ("aLiCe", 3.0)] {
+        let body = NewUserCoords {
+            name: name.into(),
+            latitude: lat,
+            longitude: 0.0,
+        };
+        let resp = client
+            .post(format!("{}/api/coords", base_url))
+            .insert_header(("Authorization", format!("Bearer {}", "test-token")))
+            .send_json(&body)
+            .await
+            .expect("post ok");
+        assert!(resp.status().is_success());
+    }
+
+    // We expect to receive only Alice updates (2 messages)
+    let mut received = vec![];
+    for _ in 0..2 {
+        if let Some(Ok(awc::ws::Frame::Text(bytes))) = ws.next().await {
+            let text = String::from_utf8(bytes.to_vec()).unwrap();
+            let json: Value = serde_json::from_str(&text).unwrap();
+            received.push(json);
+        }
+    }
+    assert_eq!(received.len(), 2);
+    assert!(received.iter().all(|j| j["name"] == "Alice"));
+}
+
+#[actix_web::test]
+async fn ws_per_user_snapshot_on_connect() {
+    let pool = setup_pool().await;
+    let token = "test-token".to_string();
+    let (coords_update_sender, _unused_receiver) = tokio::sync::broadcast::channel(64);
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let server = HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(AppState {
+                db: pool.clone(),
+                auth_token: token.clone(),
+                notifier: coords_update_sender.clone(),
+            }))
+            .configure(configure_api)
+    })
+    .listen(listener)
+    .expect("listen")
+    .run();
+    let _handle = actix_web::rt::spawn(server);
+    let base_url = format!("http://{}", addr);
+
+    let client = awc::Client::new();
+
+    // Pre-insert user via REST
+    let body = NewUserCoords {
+        name: "Snap".into(),
+        latitude: 42.0,
+        longitude: 24.0,
+    };
+    let resp = client
+        .post(format!("{}/api/coords", base_url))
+        .insert_header(("Authorization", format!("Bearer {}", "test-token")))
+        .send_json(&body)
+        .await
+        .expect("post ok");
+    assert!(resp.status().is_success());
+
+    // Connect to per-user WS and expect an immediate snapshot message
+    let url = ws_url(&base_url, "/ws/coords/SNAP");
+    let (_resp, mut ws) = client.ws(url).connect().await.expect("ws connect");
+
+    if let Some(Ok(awc::ws::Frame::Text(bytes))) = ws.next().await {
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["name"], "Snap");
+        assert_eq!(json["latitude"], 42.0);
+        assert_eq!(json["longitude"], 24.0);
+    } else {
+        panic!("expected snapshot frame");
+    }
+}
+
+#[actix_web::test]
+async fn ws_all_users_initial_snapshot_like_updates() {
+    let pool = setup_pool().await;
+    let token = "test-token".to_string();
+    let (coords_update_sender, _unused_receiver) = tokio::sync::broadcast::channel(64);
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let server = HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(AppState {
+                db: pool.clone(),
+                auth_token: token.clone(),
+                notifier: coords_update_sender.clone(),
+            }))
+            .configure(configure_api)
+    })
+    .listen(listener)
+    .expect("listen")
+    .run();
+    let _handle = actix_web::rt::spawn(server);
+    let base_url = format!("http://{}", addr);
+
+    let client = awc::Client::new();
+
+    // Pre-insert two users via REST
+    for (name, lat) in [("Alice", 1.0_f64), ("Bob", 2.0_f64)] {
+        let body = NewUserCoords {
+            name: name.into(),
+            latitude: lat,
+            longitude: 0.0,
+        };
+        let resp = client
+            .post(format!("{}/api/coords", base_url))
+            .insert_header(("Authorization", format!("Bearer {}", "test-token")))
+            .send_json(&body)
+            .await
+            .expect("post ok");
+        assert!(resp.status().is_success());
+    }
+
+    // Connect with initial=1; expect to receive two frames representing Alice and Bob, order not guaranteed
+    let url = ws_url(&base_url, "/ws/coords?initial=1");
+    let (_resp, mut ws) = client.ws(url).connect().await.expect("ws connect");
+
+    let mut names = vec![];
+    for _ in 0..2 {
+        if let Some(Ok(awc::ws::Frame::Text(bytes))) = ws.next().await {
+            let text = String::from_utf8(bytes.to_vec()).unwrap();
+            let json: Value = serde_json::from_str(&text).unwrap();
+            names.push(json["name"].as_str().unwrap().to_string());
+        } else {
+            panic!("expected text frame");
+        }
+    }
+    names.sort();
+    assert_eq!(names, vec!["Alice".to_string(), "Bob".to_string()]);
+
+    // Now send a new update and check it arrives after the initial ones
+    let body = NewUserCoords {
+        name: "Alice".into(),
+        latitude: 9.9,
+        longitude: 9.9,
+    };
+    let resp = client
+        .post(format!("{}/api/coords", base_url))
+        .insert_header(("Authorization", format!("Bearer {}", "test-token")))
+        .send_json(&body)
+        .await
+        .expect("post ok");
+    assert!(resp.status().is_success());
+
+    if let Some(Ok(awc::ws::Frame::Text(bytes))) = ws.next().await {
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["name"], "Alice");
+        assert_eq!(json["latitude"], 9.9);
+        assert_eq!(json["longitude"], 9.9);
+    } else {
+        panic!("expected update frame after initial snapshot");
+    }
+}


### PR DESCRIPTION
### Summary
Streamlines WebSocket UX, unifies test setup, improves readability, and tightens docs. Adds optional initial snapshot for all‑users WS without breaking existing clients.

### Key changes
- WebSocket all‑users: `GET /ws/coords?initial=1|true` sends a one‑time initial load as individual `UserCoords` frames, then live updates.
- WebSocket per‑user: case‑insensitive filtering and immediate snapshot (if recent).
- Tests: all apps use `configure_api` (single source of truth for routes/middleware).
- Readability: replaced `tx`/`rx` and other short names with descriptive ones in server, WS handlers, and tests.
- OpenAPI: documents `/ws/coords` `initial` query parameter and includes WS endpoints.
- Doctests: added/fixed for `utils::ws_url`, `models::NewUserCoords`, and OpenAPI presence.

### Notes
- REST API unchanged; WS change is opt‑in via `initial`.
- Clippy clean; doctests pass. Integration tests spin up a real `HttpServer` on ephemeral ports.
